### PR TITLE
fix(mdx): #23 missing ﻿process.env.NODE_ENV if MDX is used with CLI

### DIFF
--- a/.changeset/nice-laws-march.md
+++ b/.changeset/nice-laws-march.md
@@ -1,0 +1,5 @@
+---
+"@content-collections/mdx": patch
+---
+
+Fix missing process.env.NODE_ENV if mdx is used with cli

--- a/packages/mdx/src/index.ts
+++ b/packages/mdx/src/index.ts
@@ -73,6 +73,14 @@ async function compile(document: Document, options: Options = {}) {
     source: document.content,
     cwd: options.cwd,
     files,
+    esbuildOptions(options) {
+      if (!options.define) {
+        options.define = {};
+      }
+      const env = process.env.NODE_ENV ?? "production";
+      options.define["process.env.NODE_ENV"] = JSON.stringify(env);
+      return options;
+    },
     mdxOptions(mdxOptions) {
       mdxOptions.rehypePlugins = [
         ...(options.rehypePlugins ?? []),


### PR DESCRIPTION
Closes: #23