### PR TITLE
fix(core): mark all packages as external

### DIFF
--- a/.changeset/fair-chairs-melt.md
+++ b/.changeset/fair-chairs-melt.md
@@ -1,0 +1,5 @@
+---
+"@content-collections/core": patch
+---
+
+mark all packages as external

--- a/turbo.json
+++ b/turbo.json
@@ -23,6 +23,7 @@
       "dependsOn": ["^test", "^lint"]
     },
     "dev": {
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     }


### PR DESCRIPTION
Add an esbuild plugins which mark all paths,
which do not start with "/", "." or ".." as external. This should fix import errors in some situations.