### PR TITLE
fix(core): #131 type error if declaration is set to true in tsconfig

### DIFF
--- a/.changeset/few-stingrays-bow.md
+++ b/.changeset/few-stingrays-bow.md
@@ -1,0 +1,5 @@
+---
+"@content-collections/core": patch
+---
+
+Do now show type errors on defineConfig, if declaration is set to true in the tsconfig.

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -4,6 +4,11 @@ import { Parser, Parsers } from "./parser";
 import { CacheFn } from "./cache";
 import { NotSerializableError, Serializable } from "./serializer";
 
+// Export all zod types to fix type errors,
+// if declaration is set to true in tsconfig.json.
+// @see https://github.com/microsoft/TypeScript/issues/42873
+export type * from "zod";
+
 export type Meta = {
   filePath: string;
   fileName: string;


### PR DESCRIPTION
Do now show type errors on defineConfig, if declaration is set to true in the tsconfig. 
We export all zod types to fix the type error.

See https://github.com/microsoft/TypeScript/issues/42873