### PR TITLE
fix(website): use mdx instead of content

### DIFF
--- a/docs/content/mdx.mdx
+++ b/docs/content/mdx.mdx
@@ -53,7 +53,7 @@ export default function App() {
         {allPosts.map((post) => (
           <li key={post._meta.path}>
             <h2>{post.title}</h2>
-            <MDXContent code={post.content} />
+            <MDXContent code={post.mdx} />
           </li>
         ))}
       </ul>


### PR DESCRIPTION
Seems to be typo in the docs. Once you configure MDX with content-collections, the `mdx` variable is what needs to be used with the `<MDXContent />` component. 