### PR TITLE
fix(website): Fix typo in  useMDXComponents

### DIFF
--- a/docs/content/mdx.mdx
+++ b/docs/content/mdx.mdx
@@ -128,9 +128,9 @@ The compiled MDX content as a string.
 
 An object containing components for MDX content. The components prop can override the default components. For more details, refer to the [MDX documentation](https://mdxjs.com/table-of-components/#components).
 
-### useMDXComponents
+### useMDXComponent
 
-The `useMDXComponents` hook is requires the raw MDX content as parameter and returns a React component. The component can be used to render the MDX content. The hook takes the following arguments:
+The `useMDXComponent` hook is requires the raw MDX content as parameter and returns a React component. The component can be used to render the MDX content. The hook takes the following arguments:
 
 #### `components` (optional)
 


### PR DESCRIPTION
I think there might be a typo in the documentation for `useMDXComponents`. It seems it should be `useMDXComponent` without the `s`. I had some trouble finding the correct import until I realized this. Just wanted to point it out to help others avoid the same issue! 😅