### PR TITLE
fix(core): #215 frontmatter parsing on windows

### DIFF
--- a/.changeset/eleven-games-think.md
+++ b/.changeset/eleven-games-think.md
@@ -1,0 +1,5 @@
+---
+"@content-collections/core": patch
+---
+
+Fix frontmatter parsing in certain situations on Windows.

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -4,11 +4,15 @@ import { parse, stringify } from "yaml";
 export type Parsers = typeof parsers;
 export type Parser = keyof typeof parsers;
 
+function parseYaml(content: string) {
+  return parse(content.trim());
+}
+
 function frontmatterParser(fileContent: string) {
   const { data, content } = matter(fileContent, {
     engines: {
       yaml: {
-        parse,
+        parse: parseYaml,
         stringify,
       },
     },
@@ -31,6 +35,6 @@ export const parsers = {
   },
   yaml: {
     hasContent: false,
-    parse,
+    parse: parseYaml,
   },
 } as const;


### PR DESCRIPTION
Trim the content before it is passed to the yaml parser. This should fix frontmatter parsing on windows.

Closes: #215