### PR TITLE
Fix Solid Start adapter

### DIFF
--- a/.changeset/seven-shrimps-train.md
+++ b/.changeset/seven-shrimps-train.md
@@ -2,4 +2,4 @@
 "@content-collections/solid-start": patch
 ---
 
-Fix Solid Start adapter
+Fix build of solid-start apps, by generating the collections on the ssr phase instead of the server-fns phase.

--- a/.changeset/seven-shrimps-train.md
+++ b/.changeset/seven-shrimps-train.md
@@ -1,0 +1,5 @@
+---
+"@content-collections/solid-start": patch
+---
+
+Fix Solid Start adapter

--- a/packages/solid-start/src/index.ts
+++ b/packages/solid-start/src/index.ts
@@ -7,6 +7,7 @@ export default function remixContentCollectionsPlugin(
   const plugin = contentCollectionsPlugin({
     ...(options || {}),
     isEnabled(config) {
+      // @ts-ignore router is an solid-start internal property
       return config.router?.name === "ssr";
     },
   });

--- a/packages/solid-start/src/index.ts
+++ b/packages/solid-start/src/index.ts
@@ -7,10 +7,7 @@ export default function remixContentCollectionsPlugin(
   const plugin = contentCollectionsPlugin({
     ...(options || {}),
     isEnabled(config) {
-      if (config.base === "/_build") {
-        return true;
-      }
-      return false;
+      return config.router?.name === "ssr";
     },
   });
 

--- a/packages/solid-start/src/index.ts
+++ b/packages/solid-start/src/index.ts
@@ -7,7 +7,7 @@ export default function remixContentCollectionsPlugin(
   const plugin = contentCollectionsPlugin({
     ...(options || {}),
     isEnabled(config) {
-      if (config.base === "/_server") {
+      if (config.base === "/_build") {
         return true;
       }
       return false;


### PR DESCRIPTION
When running `vinxi build` on a Solid Start app the project builds in the following order:
 - Router `ssr` at base path `/_build`
 - Router `client` at base path `/_build`
 - Router `server-fns` at base path `/_server`

Based on this we can see that the `isEnabled` fn will only return `true` on the last phase of the build. In practice this means the build fails on the first step due to missing files in the codegen directory.

This PR ensures the `isEnabled` flag is true for the first step which is the `ssr` one.
