### PR TITLE
refactor(core): use picomatch and tinyglobby

### DIFF
--- a/.changeset/cuddly-flowers-nail.md
+++ b/.changeset/cuddly-flowers-nail.md
@@ -1,0 +1,5 @@
+---
+"@content-collections/core": minor
+---
+
+Use smaller and faster glob libraries. Replace micromatch with picomatch and fast-glob with tinyglobby.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,8 +26,8 @@
     "typescript": "^5.0.2"
   },
   "devDependencies": {
-    "@types/micromatch": "^4.0.9",
     "@types/node": "^20.14.9",
+    "@types/picomatch": "^3.0.1",
     "@types/pluralize": "^0.0.33",
     "@types/serialize-javascript": "^5.0.4",
     "@vitest/coverage-v8": "^2.0.5",
@@ -41,12 +41,12 @@
     "bundle-require": "^5.0.0",
     "camelcase": "^8.0.0",
     "esbuild": "^0.21.4",
-    "fast-glob": "^3.3.2",
     "gray-matter": "^4.0.3",
-    "micromatch": "^4.0.8",
     "p-limit": "^6.1.0",
+    "picomatch": "^4.0.2",
     "pluralize": "^8.0.0",
     "serialize-javascript": "^6.0.2",
+    "tinyglobby": "^0.2.5",
     "yaml": "^2.4.5",
     "zod": "^3.23.8"
   }

--- a/packages/core/src/collector.ts
+++ b/packages/core/src/collector.ts
@@ -1,4 +1,4 @@
-import fg from "fast-glob";
+import { glob } from "tinyglobby";
 import { readFile } from "fs/promises";
 import path from "path";
 import { isDefined, orderByPath } from "./utils";
@@ -81,7 +81,9 @@ export function createCollector(emitter: Emitter, baseDirectory: string = ".") {
   async function resolveCollection<T extends FileCollection>(collection: T) {
     const collectionDirectory = path.join(baseDirectory, collection.directory);
 
-    const filePaths = await fg(collection.include, {
+    const include = Array.isArray(collection.include) ? collection.include : [collection.include];
+
+    const filePaths = await glob(include, {
       cwd: collectionDirectory,
       onlyFiles: true,
       absolute: false,

--- a/packages/core/src/synchronizer.ts
+++ b/packages/core/src/synchronizer.ts
@@ -1,4 +1,4 @@
-import micromatch from "micromatch";
+import picomatch from "picomatch";
 import { CollectionFile, FileCollection, ResolvedCollection } from "./types";
 import path from "node:path";
 import { orderByPath } from "./utils";
@@ -45,7 +45,7 @@ export function createSynchronizer<T extends FileCollection>(
         };
       })
       .filter(({ collection, relativePath }) => {
-        return micromatch.isMatch(relativePath, collection.include, {
+        return picomatch.isMatch(relativePath, collection.include, {
           ignore: collection.exclude,
         });
       });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,24 +66,24 @@ importers:
       esbuild:
         specifier: ^0.21.4
         version: 0.21.4
-      fast-glob:
-        specifier: ^3.3.2
-        version: 3.3.2
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
-      micromatch:
-        specifier: ^4.0.8
-        version: 4.0.8
       p-limit:
         specifier: ^6.1.0
         version: 6.1.0
+      picomatch:
+        specifier: ^4.0.2
+        version: 4.0.2
       pluralize:
         specifier: ^8.0.0
         version: 8.0.0
       serialize-javascript:
         specifier: ^6.0.2
         version: 6.0.2
+      tinyglobby:
+        specifier: ^0.2.5
+        version: 0.2.5
       yaml:
         specifier: ^2.4.5
         version: 2.4.5
@@ -91,12 +91,12 @@ importers:
         specifier: ^3.23.8
         version: 3.23.8
     devDependencies:
-      '@types/micromatch':
-        specifier: ^4.0.9
-        version: 4.0.9
       '@types/node':
         specifier: ^20.14.9
         version: 20.14.9
+      '@types/picomatch':
+        specifier: ^3.0.1
+        version: 3.0.1
       '@types/pluralize':
         specifier: ^0.0.33
         version: 0.0.33
@@ -5706,6 +5706,7 @@ packages:
 
   /@types/braces@3.0.4:
     resolution: {integrity: sha512-0WR3b8eaISjEW7RpZnclONaLFDf7buaowRHdqLp4vLj54AsSAYWfh3DRbfiYJY9XDxMgx1B4sE1Afw2PGpuHOA==}
+    dev: false
 
   /@types/conventional-commits-parser@5.0.0:
     resolution: {integrity: sha512-loB369iXNmAZglwWATL+WRe+CRMmmBPtpolYzIebFaX4YA3x+BEfLqhUAV9WanycKI3TG1IMr5bMJDajDKLlUQ==}
@@ -5784,6 +5785,7 @@ packages:
     resolution: {integrity: sha512-7V+8ncr22h4UoYRLnLXSpTxjQrNUXtWHGeMPRJt1nULXI57G9bIcpyrHlmrQ7QK24EyyuXvYcSSWAM8GA9nqCg==}
     dependencies:
       '@types/braces': 3.0.4
+    dev: false
 
   /@types/minimist@1.2.5:
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
@@ -5820,6 +5822,10 @@ packages:
 
   /@types/normalize-package-data@2.4.4:
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+    dev: true
+
+  /@types/picomatch@3.0.1:
+    resolution: {integrity: sha512-1MRgzpzY0hOp9pW/kLRxeQhUWwil6gnrUYd3oEpeYBqp/FexhaCPv3F8LsYr47gtUU45fO2cm1dbwkSrHEo8Uw==}
     dev: true
 
   /@types/pluralize@0.0.33:
@@ -8892,6 +8898,17 @@ packages:
     resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
     dependencies:
       format: 0.2.2
+
+  /fdir@6.3.0(picomatch@4.0.2):
+    resolution: {integrity: sha512-QOnuT+BOtivR77wYvCWHfGt9s4Pz1VIMbD463vegT5MLqNXy8rYFT/lPVEqf/bhYeT6qmqrNHhsX+rWwe3rOCQ==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+    dependencies:
+      picomatch: 4.0.2
+    dev: false
 
   /figures@5.0.0:
     resolution: {integrity: sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==}
@@ -12789,6 +12806,11 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  /picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+    dev: false
+
   /pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
@@ -14824,6 +14846,14 @@ packages:
   /tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
     dev: true
+
+  /tinyglobby@0.2.5:
+    resolution: {integrity: sha512-Dlqgt6h0QkoHttG53/WGADNh9QhcjCAIZMTERAVhdpmIBEejSuLI9ZmGKWzB7tweBjlk30+s/ofi4SLmBeTYhw==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      fdir: 6.3.0(picomatch@4.0.2)
+      picomatch: 4.0.2
+    dev: false
 
   /tinypool@1.0.1:
     resolution: {integrity: sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==}


### PR DESCRIPTION
Use smaller and faster glob libraries.
Replace micromatch with picomatch and fast-glob with tinyglobby. This change should speed up the process of file collection.