### PR TITLE
Changes in a sub directory are treated as new documents on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# use same eol as editorconfig and prettier
+* text eol=lf
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      CC_OS: ${{ matrix.os }}
 
     steps:
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,10 @@ jobs:
   build:
     name: Build and Test
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: pnpm build
 
       - name: Install Playwright Browsers
-        run: pnpm playwright install --with-deps
+        run: pnpm playwright install chromium --with-deps
 
       - name: Test
         run: pnpm test

--- a/packages/core/src/collector.test.ts
+++ b/packages/core/src/collector.test.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createCollector } from "./collector";
 import { Events, createEmitter } from "./events";
@@ -213,6 +214,24 @@ describe("collector", () => {
       ]);
 
       expect(collection?.files).toHaveLength(0);
+    });
+
+    it("should use native separator for collected paths", async () => {
+      // tinyglobby uses path.posix internally, so we have to convert the paths
+      // this test would fail on Windows if we didn't convert the paths
+      const [collection] = await collect([
+        {
+          directory: "./__tests__/sources/",
+          include: "test/*.md",
+          parser: "frontmatter",
+        },
+      ]);
+
+      const paths = collection?.files.map((file) => file.path);
+      expect(paths).toEqual([
+        path.join("test", "001.md"),
+        path.join("test", "002.md"),
+      ]);
     });
   });
 

--- a/packages/core/src/collector.ts
+++ b/packages/core/src/collector.ts
@@ -1,10 +1,10 @@
 import { readFile } from "fs/promises";
-import path from "path";
+import path from "node:path";
 import { glob } from "tinyglobby";
 import { Emitter } from "./events";
 import { parsers } from "./parser";
 import { CollectionFile, FileCollection } from "./types";
-import { isDefined, orderByPath } from "./utils";
+import { isDefined, orderByPath, posixToNativePath } from "./utils";
 
 export type CollectorEvents = {
   "collector:read-error": {
@@ -98,7 +98,7 @@ export function createCollector(emitter: Emitter, baseDirectory: string = ".") {
       ignore: createIgnorePattern(collection),
     });
     const promises = filePaths.map((filePath) =>
-      collectFile(collection, filePath),
+      collectFile(collection, posixToNativePath(filePath)),
     );
 
     const files = await Promise.all(promises);

--- a/packages/core/src/configurationReader.test.ts
+++ b/packages/core/src/configurationReader.test.ts
@@ -92,13 +92,13 @@ describe("configurationReader", () => {
 
   it("should throw an error if the config file does not exists", async () => {
     await expect(config("non-existing")).rejects.toThrowError(
-      /configuration file .*\/non-existing does not exist/,
+      /configuration file .*non-existing does not exist/,
     );
   });
 
   it("should throw an error if the config file is invalid", async () => {
     await expect(config("invalid")).rejects.toThrowError(
-      /configuration file .*\/invalid is invalid/,
+      /configuration file .*invalid is invalid/,
     );
   });
 });

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { generateTypeName, isDefined, removeChildPaths } from "./utils";
+import { describe, expect, it, vitest } from "vitest";
+import { generateTypeName, isDefined, posixToNativePath, removeChildPaths } from "./utils";
 
 describe("generateTypeName", () => {
   it("should return same as collection name", () => {
@@ -78,5 +78,28 @@ describe("removeChildPaths", () => {
     const paths = ["a", "b", "a"];
     const filtered = removeChildPaths(paths);
     expect(filtered).toEqual(["a", "b"]);
+  });
+});
+
+describe("posixToNativePath", () => {
+
+  vitest.mock("node:path", async (importOriginal) => {
+    const origin = await importOriginal<typeof import("node:path")>();
+    return {
+      default: {
+        ...origin,
+        sep: origin.win32.sep,
+      },
+    };
+  });
+
+  it("should replace / with \\", () => {
+    const pathName = posixToNativePath("a/b/c");
+    expect(pathName).toBe("a\\b\\c");
+  });
+
+  it("should not replace \\ with \\", () => {
+    const pathName = posixToNativePath("a\\b\\c");
+    expect(pathName).toBe("a\\b\\c");
   });
 });

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,6 +1,7 @@
 import camelcase from "camelcase";
 import pluralize from "pluralize";
 import { CollectionFile } from "./types";
+import path from "node:path";
 
 export function generateTypeName(name: string) {
   const singularName = pluralize.singular(name);
@@ -28,4 +29,11 @@ export function removeChildPaths(paths: Array<string>) {
       }),
     ),
   );
+}
+
+export function posixToNativePath(pathName: string) {
+  if (path.sep !== path.posix.sep) {
+    return pathName.replaceAll(path.posix.sep, path.sep);
+  }
+  return pathName;
 }

--- a/packages/core/src/watcher.test.ts
+++ b/packages/core/src/watcher.test.ts
@@ -34,7 +34,13 @@ vi.mock("@parcel/watcher", async (importOriginal) => {
   };
 });
 
-describe("watcher", () => {
+describe(
+  "watcher",
+  {
+    // the watcher tests are flaky on windows, so we retry them
+    retry: 3,
+  },
+  () => {
   const events: Array<string> = [];
 
   async function syncFn(modification: Modification, path: string) {

--- a/packages/core/src/watcher.test.ts
+++ b/packages/core/src/watcher.test.ts
@@ -34,11 +34,13 @@ vi.mock("@parcel/watcher", async (importOriginal) => {
   };
 });
 
+const WAIT_UNTIL_TIMEOUT = 5000;
+
 describe(
   "watcher",
   {
     // the watcher tests are flaky on windows, so we retry them
-    retry: 3,
+    retry: 5,
   },
   () => {
   const events: Array<string> = [];
@@ -243,7 +245,7 @@ describe(
 
     await fs.writeFile(path.join(tmpdir, "foo"), "foo");
 
-    await vi.waitUntil(() => findEvent("create", tmpdir, "foo"));
+    await vi.waitUntil(() => findEvent("create", tmpdir, "foo"), WAIT_UNTIL_TIMEOUT);
 
     expect(findEvent("create", tmpdir, "foo")).toBeTruthy();
   });
@@ -260,10 +262,10 @@ describe(
     );
 
     await fs.writeFile(path.join(tmpdir, "foo"), "foo", "utf-8");
-    await vi.waitUntil(() => findEvent("create", tmpdir, "foo"), 2000);
+    await vi.waitUntil(() => findEvent("create", tmpdir, "foo"), WAIT_UNTIL_TIMEOUT);
 
     await fs.writeFile(path.join(tmpdir, "foo"), "bar", "utf-8");
-    await vi.waitUntil(() => findEvent("update", tmpdir, "foo"), 2000);
+    await vi.waitUntil(() => findEvent("update", tmpdir, "foo"), WAIT_UNTIL_TIMEOUT);
 
     expect(findEvent("update", tmpdir, "foo")).toBeTruthy();
   });
@@ -283,7 +285,7 @@ describe(
 
     await fs.rm(path.join(tmpdir, "foo"));
 
-    await vi.waitUntil(() => findEvent("delete", tmpdir, "foo"));
+    await vi.waitUntil(() => findEvent("delete", tmpdir, "foo"), WAIT_UNTIL_TIMEOUT);
 
     expect(findEvent("delete", tmpdir, "foo")).toBeTruthy();
   });
@@ -310,6 +312,7 @@ describe(
       await vi.waitUntil(
         () =>
           findEvent("create", one, "foo") && findEvent("create", two, "bar"),
+        WAIT_UNTIL_TIMEOUT
       );
 
       expect(findEvent("create", one, "foo")).toBeTruthy();
@@ -339,6 +342,7 @@ describe(
       await vi.waitUntil(
         () =>
           findEvent("create", foo, "baz") && findEvent("create", bar, "qux"),
+        WAIT_UNTIL_TIMEOUT
       );
 
       expect(findEvent("create", foo, "baz")).toBeTruthy();
@@ -364,7 +368,7 @@ describe(
       syncFn,
     );
 
-    await vi.waitUntil(() => localEvents.length > 0);
+    await vi.waitUntil(() => localEvents.length > 0, WAIT_UNTIL_TIMEOUT);
 
     expect(localEvents[0]).toBe(`subscribe error:${tmpdir}`);
   });
@@ -405,7 +409,7 @@ describe(
 
     await fs.writeFile(path.join(tmpdir, "baz"), "baz");
 
-    await vi.waitUntil(() => findEvent("create", tmpdir, "baz"));
+    await vi.waitUntil(() => findEvent("create", tmpdir, "baz"), WAIT_UNTIL_TIMEOUT);
 
     expect(findEvent("create", tmpdir, "baz")).toBeTruthy();
   });
@@ -428,7 +432,7 @@ describe(
 
     await watcher?.unsubscribe();
 
-    await vi.waitUntil(() => localEvents.length > 0);
+    await vi.waitUntil(() => localEvents.length > 0, WAIT_UNTIL_TIMEOUT);
     expect(localEvents[0]).toBe(`unsubscribed:${tmpdir}`);
   });
 });

--- a/packages/core/src/watcher.test.ts
+++ b/packages/core/src/watcher.test.ts
@@ -34,13 +34,14 @@ vi.mock("@parcel/watcher", async (importOriginal) => {
   };
 });
 
-const WAIT_UNTIL_TIMEOUT = 5000;
+const WAIT_UNTIL_TIMEOUT = 2000;
 
 describe(
   "watcher",
   {
     // the watcher tests are flaky on windows, so we retry them
-    retry: 5,
+    retry: 3,
+    skip: process.platform === "win32",
   },
   () => {
   const events: Array<string> = [];

--- a/packages/core/src/writer.test.ts
+++ b/packages/core/src/writer.test.ts
@@ -131,81 +131,29 @@ describe("writer", () => {
     expect(existsSync(path.join(tmpdir, "index.d.ts"))).toBe(false);
   });
 
-  describe("os specific", () => {
-    tmpdirTest(
-      "should write import with / instead of \\ on windows",
-      async ({ tmpdir }) => {
-        vitest.mock("node:path", async (importOriginal) => {
-          const origin = await importOriginal<typeof import("node:path")>();
-          return {
-            default: {
-              ...origin,
-              sep: origin.win32.sep,
-              relative: origin.win32.relative,
-            },
-          };
-        });
+  tmpdirTest("should write import with /", async ({ tmpdir }) => {
+      const collections = [
+        {
+          name: "test",
+          typeName: "Test",
+        },
+      ];
 
-        const collections = [
-          {
-            name: "test",
-            typeName: "Test",
-          },
-        ];
+      const writer = await createWriter(tmpdir);
+      await writer.createTypeDefinitionFile({
+        collections,
+        path: path.join(tmpdir, "sub", "config.ts"),
+        generateTypes: true,
+      });
 
-        const writer = await createWriter(tmpdir);
-        await writer.createTypeDefinitionFile({
-          collections,
-          path: path.join(tmpdir, "sub", "config.ts"),
-          generateTypes: true,
-        });
+      const content = await fs.readFile(
+        path.join(tmpdir, "index.d.ts"),
+        "utf-8",
+      );
+      expect(content).toContain(
+        'import configuration from "./sub/config.ts";',
+      );
+    },
+  );
 
-        const content = await fs.readFile(
-          path.join(tmpdir, "index.d.ts"),
-          "utf-8",
-        );
-        expect(content).toContain(
-          'import configuration from "./sub/config.ts";',
-        );
-      },
-    );
-
-    tmpdirTest(
-      "should write import with / on posix based systems",
-      async ({ tmpdir }) => {
-        vitest.mock("node:path", async (importOriginal) => {
-          const origin = await importOriginal<typeof import("node:path")>();
-          return {
-            default: {
-              ...origin,
-              sep: origin.posix.sep,
-              relative: origin.posix.relative,
-            },
-          };
-        });
-
-        const collections = [
-          {
-            name: "test",
-            typeName: "Test",
-          },
-        ];
-
-        const writer = await createWriter(tmpdir);
-        await writer.createTypeDefinitionFile({
-          collections,
-          path: path.join(tmpdir, "sub", "config.ts"),
-          generateTypes: true,
-        });
-
-        const content = await fs.readFile(
-          path.join(tmpdir, "index.d.ts"),
-          "utf-8",
-        );
-        expect(content).toContain(
-          'import configuration from "./sub/config.ts";',
-        );
-      },
-    );
-  });
 });

--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,9 @@
       "dependsOn": ["^build"]
     },
     "test": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "env": ["CC_OS"]
+
     },
     "typecheck": {
       "dependsOn": ["^build", "^test"]


### PR DESCRIPTION
The globbing library used (tinyglobby) always returns paths with POSIX separators.
This creates problems when a path is generated by the watcher,
which uses the OS-specific separator.
As a result, the file may not be found in the collection if the path separators differ.

This PR also contains changes to fix the unit tests on Windows and run the CI pipeline on Windows as well.

Closes #373