### PR TITLE
docs: fix the typo in code example of next-mdx-static-import

### DIFF
--- a/samples/next-mdx-static-import/README.md
+++ b/samples/next-mdx-static-import/README.md
@@ -34,10 +34,11 @@ const posts = defineCollection({
   name: "posts",
   directory: "./content/posts",
   include: "*.mdx",
+  parser: "frontmatter-only",
   schema: (z) => ({
     title: z.string(),
   }),
-  transform: ({ content: _, ...post }) => {
+  transform: ({ _meta, ...post }) => {
     const mdxContent = createDefaultImport<MDXContent>(`@/content/posts/${_meta.filePath}`);
     return {
       ...post,

--- a/samples/next-mdx-static-import/README.md
+++ b/samples/next-mdx-static-import/README.md
@@ -37,6 +37,7 @@ const posts = defineCollection({
   parser: "frontmatter-only",
   schema: (z) => ({
     title: z.string(),
+    slug: z.string(),
   }),
   transform: ({ _meta, ...post }) => {
     const mdxContent = createDefaultImport<MDXContent>(`@/content/posts/${_meta.filePath}`);


### PR DESCRIPTION
Hi there, thanks for the awesome library!

I noticed a typo in the `next-mdx-static-import` README, so I created a fix for it. If I missed something obvious, feel free to close this.

By the way, this feature looks great! Will it be released in the next version?