### PR TITLE
fix(next): #499 rerun on sigint

### DIFF
--- a/.changeset/nice-ghosts-kick.md
+++ b/.changeset/nice-ghosts-kick.md
@@ -1,0 +1,5 @@
+---
+"@content-collections/next": patch
+---
+
+Fix rerun on sigint

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -19,6 +19,13 @@ export function createContentCollectionPlugin(pluginOptions: Options) {
       .slice(2)
       .filter((arg) => !arg.startsWith("-"));
     if (command === "build" || command === "dev") {
+      if (process.ppid === 1) {
+        // if the parent process is 1, we assume that the parent process was killed
+        // and we are running in a new process, so we skip the initialization
+        // https://github.com/sdorra/content-collections/issues/499
+        return nextConfig;
+      }
+
       const initialized = initializedState[pluginOptions.configPath];
 
       if (initialized) {


### PR DESCRIPTION
If the parent process has an ID of 1,
we assume that the original parent process was terminated. In this case, we run a new process that evaluates the next configuration, allowing us to skip the initialization.

Closes: #499