### PR TITLE
fix(shared): #505 cache collisions between markdown and mdx package

### DIFF
--- a/.changeset/new-schools-listen.md
+++ b/.changeset/new-schools-listen.md
@@ -1,0 +1,5 @@
+---
+"@content-collections/mdx": patch
+---
+
+Pass key to cache function to avoid collisions with markdown package

--- a/.changeset/tall-cows-worry.md
+++ b/.changeset/tall-cows-worry.md
@@ -1,0 +1,5 @@
+---
+"@content-collections/core": patch
+---
+
+Add name to cache function to avoid collisions

--- a/.changeset/wicked-falcons-report.md
+++ b/.changeset/wicked-falcons-report.md
@@ -1,0 +1,5 @@
+---
+"@content-collections/markdown": patch
+---
+
+Pass key to cache function to avoid collisions with mdx package

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -1,19 +1,90 @@
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
-import path, { join } from "node:path";
+import path, { join } from "path";
 
-export type CacheFn = <TInput, TOutput>(
+export type CacheFn = {
+  /**
+   * @deprecated Use the overloaded function with `name` as the first parameter instead.
+   * Without the additional `name` parameter it can lead to cache collisions.
+   * This function will be removed in a future version.
+   *
+   * @see https://github.com/sdorra/content-collections/issues/505
+   */
+  <TInput, TOutput>(
+    input: TInput,
+    compute: (input: TInput) => Promise<TOutput> | TOutput,
+    name?: string,
+  ): Promise<TOutput>;
+  <TInput, TOutput>(
+    name: string,
+    input: TInput,
+    compute: (input: TInput) => Promise<TOutput> | TOutput,
+  ): Promise<TOutput>;
+};
+
+type ComputeFn = (input: unknown) => Promise<unknown> | unknown;
+
+type ModernCache = <TInput, TOutput>(
+  name: string,
   input: TInput,
   compute: (input: TInput) => Promise<TOutput> | TOutput,
 ) => Promise<TOutput>;
 
-function createKey(config: string, input: unknown): string {
+export function createCacheFn(cache: ModernCache): CacheFn {
+  return (
+    arg1: string | unknown,
+    arg2: unknown | ComputeFn,
+    arg3?: ComputeFn | string,
+  ) => {
+    let name: string = "";
+    let input: unknown;
+    let fn: ComputeFn | undefined;
+
+    if (typeof arg1 === "string" && typeof arg3 === "function") {
+      // modern cache syntax
+      name = arg1;
+      input = arg2;
+      fn = arg3 as ComputeFn;
+    } else {
+      // legacy cache syntax
+      input = arg1;
+      fn = arg2 as ComputeFn;
+      if (typeof arg3 === "string") {
+        name = arg3;
+      }
+    }
+
+    return cache(name, input, fn);
+  };
+}
+
+export function noopCache<TInput, TOutput>(
+  arg1: string | TInput,
+  arg2: TInput | ((input: TInput) => Promise<TOutput> | TOutput),
+  arg3?: (input: TInput) => Promise<TOutput> | TOutput,
+): Promise<TOutput> | TOutput {
+  let computeFn: (input: TInput) => Promise<TOutput> | TOutput;
+  let input: TInput;
+
+  if (typeof arg1 === "string") {
+    input = arg2 as TInput;
+    computeFn = arg3 as (input: TInput) => Promise<TOutput> | TOutput;
+  } else {
+    input = arg1 as TInput;
+    computeFn = arg2 as (input: TInput) => Promise<TOutput> | TOutput;
+  }
+
+  return computeFn(input);
+}
+
+function createKey(config: string, name: string, input: unknown): string {
   return (
     createHash("sha256")
       // we add the config hash to the input hash to ensure that the cache is
       // invalidated when the config changes
       .update(config)
+      .update(name)
       .update(JSON.stringify(input))
       .digest("hex")
   );
@@ -86,8 +157,8 @@ export async function createCacheManager(
 
     let newFileMapping: string[] = [];
 
-    const cacheFn: CacheFn = async (input, fn) => {
-      const key = createKey(configChecksum, input);
+    const cacheFn: CacheFn = createCacheFn(async (name, input, fn) => {
+      const key = createKey(configChecksum, name, input);
 
       newFileMapping.push(key);
 
@@ -113,7 +184,7 @@ export async function createCacheManager(
       await writeFile(filePath, JSON.stringify(output));
 
       return output;
-    };
+    });
 
     const tidyUp = async () => {
       const filesToDelete =

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./builder";
 export * from "./config";
+export { createCacheFn } from "./cache";
 export type { Document, GetTypeByName, Modification } from "./types";
 
 export { CollectError } from "./collector";

--- a/packages/markdown/src/index.test.ts
+++ b/packages/markdown/src/index.test.ts
@@ -1,12 +1,10 @@
-import { Context, Meta } from "@content-collections/core";
+import { createCacheFn, Meta } from "@content-collections/core";
 import { describe, expect, it, vitest } from "vitest";
 import { compileMarkdown } from ".";
 
-type Cache = Context["cache"];
-
-const cache: Cache = (input, fn) => {
-  return fn(input) as any;
-};
+const cache = createCacheFn(async (_, input, compute) => {
+  return compute(input);
+});
 
 const sampleMeta: Meta = {
   directory: "post",

--- a/packages/markdown/src/index.ts
+++ b/packages/markdown/src/index.ts
@@ -60,5 +60,6 @@ export function compileMarkdown(
   options?: Options,
 ) {
   const cacheKey = createCacheKey(document);
-  return cache(cacheKey, (doc) => compile(doc, options));
+  // we stick with the deprecated syntax, in order to support older versions of core
+  return cache(cacheKey, (doc) => compile(doc, options), "__md");
 }

--- a/packages/mdx/src/index.test.tsx
+++ b/packages/mdx/src/index.test.tsx
@@ -1,20 +1,16 @@
-import { Context, Meta } from "@content-collections/core";
+import { createCacheFn, Meta } from "@content-collections/core";
 import { cleanup, render, renderHook, screen } from "@testing-library/react";
 import { Node, Parent } from "mdast";
 import { Pluggable, Transformer } from "unified";
 import { beforeEach, describe, expect, it, vitest } from "vitest";
-import { Options, compileMDX } from ".";
+import { compileMDX, Options } from ".";
 import {
   MDXContent as MDXClientContent,
   useMDXComponent as useClientMDXComponent,
 } from "./react/client";
 import { MDXContent, useMDXComponent } from "./react/server";
 
-type Cache = Context["cache"];
-
-const cache: Cache = (input, fn) => {
-  return fn(input) as any;
-};
+const cache = createCacheFn(async (_, input, compute) => compute(input));
 
 const sampleMeta: Meta = {
   directory: "post",

--- a/packages/mdx/src/index.ts
+++ b/packages/mdx/src/index.ts
@@ -120,5 +120,6 @@ export function compileMDX(
   options?: Options,
 ) {
   const cacheKey = createCacheKey(document);
-  return cache(cacheKey, (doc) => compile(doc, options));
+  // we stick with the deprecated syntax, in order to support older versions of core
+  return cache(cacheKey, (doc) => compile(doc, options), "__mdx");
 }


### PR DESCRIPTION
Add a name to the cache function to avoid collisions

Closes: #505