### PR TITLE
fix: #505 Resolve duplicate cache keys for mdx and markdown packages

### DIFF
--- a/.changeset/gorgeous-lamps-call.md
+++ b/.changeset/gorgeous-lamps-call.md
@@ -1,0 +1,5 @@
+---
+"@content-collections/core": patch
+---
+
+Add an option to cache the API, allowing the inclusion of an additional key to prevent cache collisions

--- a/.changeset/popular-geese-remember.md
+++ b/.changeset/popular-geese-remember.md
@@ -1,0 +1,5 @@
+---
+"@content-collections/mdx": patch
+---
+
+Pass an additional cache key to prevent cache collisions with the markdown package

--- a/.changeset/red-books-grin.md
+++ b/.changeset/red-books-grin.md
@@ -1,0 +1,5 @@
+---
+"@content-collections/markdown": patch
+---
+
+Pass an additional cache key to prevent cache collisions with the MDX package

--- a/packages/core/src/cache.test.ts
+++ b/packages/core/src/cache.test.ts
@@ -59,7 +59,7 @@ describe("cacheManager", () => {
     expect(await cache.cacheFn("input", inc)).toBe(1);
   });
 
-  tmpdirTest("should compute if key changes", async ({ tmpdir }) => {
+  tmpdirTest("should compute if input changes", async ({ tmpdir }) => {
     const cacheManager = await createCacheManager(tmpdir, "configChecksum");
     const cache = cacheManager.cache("collection", "file");
 
@@ -72,6 +72,25 @@ describe("cacheManager", () => {
 
     expect(await cache.cacheFn("i-1", inc)).toBe(1);
     expect(await cache.cacheFn("i-2", inc)).toBe(2);
+  });
+
+  tmpdirTest("should compute if key changes", async ({ tmpdir }) => {
+    const cacheManager = await createCacheManager(tmpdir, "configChecksum");
+    const cache = cacheManager.cache("collection", "file");
+
+    let counter = 0;
+
+    function inc() {
+      counter++;
+      return counter;
+    }
+
+    expect(await cache.cacheFn("input", inc, {
+      key: "key",
+    })).toBe(1);
+    expect(await cache.cacheFn("input", inc, {
+      key: "key2",
+    })).toBe(2);
   });
 
   tmpdirTest("should cache across sessions", async ({ tmpdir }) => {

--- a/packages/markdown/src/index.ts
+++ b/packages/markdown/src/index.ts
@@ -60,5 +60,7 @@ export function compileMarkdown(
   options?: Options,
 ) {
   const cacheKey = createCacheKey(document);
-  return cache(cacheKey, (doc) => compile(doc, options));
+  return cache(cacheKey, (doc) => compile(doc, options), {
+    key: "__markdown",
+  });
 }

--- a/packages/mdx/src/index.ts
+++ b/packages/mdx/src/index.ts
@@ -120,5 +120,7 @@ export function compileMDX(
   options?: Options,
 ) {
   const cacheKey = createCacheKey(document);
-  return cache(cacheKey, (doc) => compile(doc, options));
+  return cache(cacheKey, (doc) => compile(doc, options), {
+    key: "__mdx",
+  });
 }


### PR DESCRIPTION
The cache API now includes an option to pass an additional key, which helps avoid cache collisions.

Both the mdx and markdown packages have been updated to utilize this new API, resolving the cache collision issue.

Closes: #505