### PR TITLE
feat(core): add option to configure custom parser

### DIFF
--- a/.changeset/fresh-goats-accept.md
+++ b/.changeset/fresh-goats-accept.md
@@ -1,0 +1,5 @@
+---
+"@content-collections/core": minor
+---
+
+Add option to define custom parser for a collection

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -40,6 +40,41 @@ The parser used to read the documents. The parser must be one of the following v
 
 The `frontmatter-only` parser is especially useful when only the metadata of a document is utilized with Content Collections, while the content is rendered by another source.
 
+#### Custom Parser
+
+If none of the parsers are fitting your needs, you can create a custom parser. This option is available since version 0.9.0. To create a custom parser, you have to import the `defineParser` function from `@content-collections/core` and create a parser either with only a function or with an object that contains a `parse` function and a `hasContent` property. If you only provide a function, the `hasContent` property is set to `false` by default. The `parse` function takes a single string as argument, the document, and should return an object with the parsed data or an `Promise` which contains the parsed data. The `hasContent` property is a boolean that indicates that content collection has to validate that the returned document has a property called `content`.
+
+```typescript
+import {
+  defineCollection,
+  defineConfig,
+  defineParser,
+} from "@content-collections/core";
+import { parseXml } from "cool-xml-parser-library";
+
+const customParser = defineParser(async (content) => {
+  const result = await parseXml(content);
+  return result.root;
+});
+
+const movies = defineCollection({
+  name: "movies",
+  directory: "movies",
+  include: "*.xml",
+  parser: customParser,
+  schema: (z) => ({
+    title: z.string(),
+    description: z.string()
+  }),
+});
+
+export default defineConfig({
+  collections: [movies],
+});
+```
+
+If you want to see a complete example of a custom parser, check the [Xml example](/samples/xml).
+
 ### `typeName` (optional)
 
 The name of the generated TypeScript type. If the `typeName` property is not provided, the type name is generated from the collection name.

--- a/packages/core/src/collector.ts
+++ b/packages/core/src/collector.ts
@@ -2,7 +2,7 @@ import { readFile } from "fs/promises";
 import path from "node:path";
 import { glob } from "tinyglobby";
 import { Emitter } from "./events";
-import { parsers } from "./parser";
+import { getParser, parsers } from "./parser";
 import { CollectionFile, FileCollection } from "./types";
 import { isDefined, orderByPath, posixToNativePath } from "./utils";
 
@@ -56,7 +56,8 @@ export function createCollector(emitter: Emitter, baseDirectory: string = ".") {
     }
 
     try {
-      const data = parsers[collection.parser].parse(file);
+      const parser = getParser(collection.parser);
+      const data = await parser.parse(file);
 
       return {
         data,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,5 +5,6 @@ export type { Document, GetTypeByName, Modification } from "./types";
 export { CollectError } from "./collector";
 export { ConfigurationError } from "./configurationReader";
 export { createDefaultImport, createNamedImport } from "./import";
+export { defineParser } from "./parser";
 export { TransformError } from "./transformer";
 export { type Watcher } from "./watcher";

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -1,8 +1,20 @@
 import matter from "gray-matter";
 import { parse, stringify } from "yaml";
+import { ConfigurationError } from "./configurationReader";
 
-export type Parsers = typeof parsers;
-export type Parser = keyof typeof parsers;
+type ParseFn = (
+  content: string,
+) => Record<string, unknown> | Promise<Record<string, unknown>>;
+
+export type Parser = {
+  hasContent: boolean;
+  parse: ParseFn;
+};
+
+export type PredefinedParsers = typeof parsers;
+export type PredefinedParser = keyof typeof parsers;
+
+export type ConfiguredParser = PredefinedParser | Parser;
 
 function parseYaml(content: string) {
   return parse(content.trim());
@@ -51,4 +63,41 @@ export const parsers = {
     hasContent: false,
     parse: parseYaml,
   },
-} as const;
+} satisfies Record<string, Parser>;
+
+export function getParser(configuredParser: ConfiguredParser): Parser {
+  if (typeof configuredParser === "string") {
+    const parser = parsers[configuredParser];
+    if (!parser) {
+      throw new ConfigurationError(
+        "Read",
+        `Parser ${configuredParser} does not exist`,
+      );
+    }
+    return parser;
+  }
+  return configuredParser;
+}
+
+type DefineParserResult<TArgument extends Parser | ParseFn> =
+  TArgument extends Function
+    ? {
+        hasContent: false;
+        parse: ParseFn;
+      }
+    : TArgument extends infer Parser
+      ? Parser
+      : never;
+
+export function defineParser<TArgument extends Parser | ParseFn>(
+  parser: TArgument,
+): DefineParserResult<TArgument> {
+  if (typeof parser === "function") {
+    return {
+      hasContent: false,
+      parse: parser,
+    } as DefineParserResult<TArgument>;
+  }
+
+  return parser as DefineParserResult<TArgument>;
+}

--- a/packages/core/src/parsers.test.ts
+++ b/packages/core/src/parsers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parsers } from "./parser";
+import { defineParser, getParser, parsers } from "./parser";
 
 const mdContent = `---
 name: John
@@ -53,6 +53,74 @@ describe("parsers", () => {
     const data = parser.parse(yamlContent);
     expect(data).toEqual({
       name: "John",
+    });
+  });
+});
+
+describe("defineParser", () => {
+
+  it("should define a parser", () => {
+    const parser = defineParser({
+      hasContent: true,
+      parse: (content: string) => {
+        return {
+          content
+        };
+      },
+    });
+
+    expect(parser).toEqual({
+      hasContent: true,
+      parse: expect.any(Function),
+    });
+  });
+
+  it("should define a parser with only a function", () => {
+    const parser = defineParser((content: string) => {
+      return {
+        content
+      };
+    });
+
+    expect(parser).toEqual({
+      hasContent: false,
+      parse: expect.any(Function),
+    });
+  });
+
+});
+
+describe("getParser", () => {
+  it("should get a parser by name", () => {
+    const parser = parsers["frontmatter"];
+    expect(parser).toEqual({
+      hasContent: true,
+      parse: expect.any(Function),
+    });
+  });
+
+  it("should throw an error if the parser does not exist", () => {
+    expect(() => {
+      // @ts-expect-error parser does not exist
+      getParser("non-existing-parser");
+    }).toThrowError(
+      "Parser non-existing-parser does not exist",
+    );
+  });
+
+  it("should return the parser if it is already a parser", () => {
+    const configuredParser = {
+      hasContent: false,
+      parse: (content: string) => {
+        return {
+          content
+        };
+      },
+    };
+    const parser = getParser(configuredParser);
+    expect(parser).toEqual({
+      hasContent: false,
+      parse: expect.any(Function),
     });
   });
 });

--- a/packages/core/src/transformer.test.ts
+++ b/packages/core/src/transformer.test.ts
@@ -498,7 +498,6 @@ describe("transform", () => {
       include: "*.md",
       transform: (doc) => {
         throw new Error("Something went wrong");
-        return doc;
       },
     });
 

--- a/packages/core/src/transformer.ts
+++ b/packages/core/src/transformer.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { Cache, CacheManager } from "./cache";
 import { AnyCollection, Context } from "./config";
 import { Emitter } from "./events";
-import { Parser, parsers } from "./parser";
+import { ConfiguredParser, getParser, parsers } from "./parser";
 import { serializableSchema } from "./serializer";
 import { CollectionFile } from "./types";
 import { isDefined } from "./utils";
@@ -61,8 +61,8 @@ export function createTransformer(
   emitter: Emitter,
   cacheManager: CacheManager,
 ) {
-  function createSchema(parserName: Parser, schema: z.ZodRawShape) {
-    const parser = parsers[parserName];
+  function createSchema(configuredParser: ConfiguredParser, schema: z.ZodRawShape) {
+    const parser = getParser(configuredParser);
     if (!parser.hasContent) {
       return z.object(schema);
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1131,6 +1131,37 @@ importers:
         specifier: 5.4.11
         version: 5.4.11(@types/node@20.14.9)
 
+  samples/xml:
+    dependencies:
+      '@content-collections/cli':
+        specifier: 0.1.6
+        version: link:../../packages/cli
+      '@content-collections/core':
+        specifier: 0.8.2
+        version: link:../../packages/core
+      xml2js:
+        specifier: ^0.6.2
+        version: 0.6.2
+    devDependencies:
+      '@types/node':
+        specifier: '20'
+        version: 20.14.9
+      '@types/xml2js':
+        specifier: ^0.4.14
+        version: 0.4.14
+      tsx:
+        specifier: ^4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: ^5.5.4
+        version: 5.8.3
+      vite:
+        specifier: 5.4.11
+        version: 5.4.11(@types/node@20.14.9)
+      vitest:
+        specifier: ^3.1.3
+        version: 3.1.3(@types/node@20.14.9)(happy-dom@15.11.4)
+
   utils/prettier-config:
     dependencies:
       prettier:
@@ -6779,7 +6810,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-android-arm64@4.40.0:
@@ -6794,7 +6824,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-darwin-arm64@4.40.0:
@@ -6809,7 +6838,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-darwin-x64@4.40.0:
@@ -6824,7 +6852,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-freebsd-arm64@4.40.0:
@@ -6839,7 +6866,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-freebsd-x64@4.40.0:
@@ -6854,7 +6880,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm-gnueabihf@4.40.0:
@@ -6869,7 +6894,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm-musleabihf@4.40.0:
@@ -6884,7 +6908,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm64-gnu@4.40.0:
@@ -6899,7 +6922,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm64-musl@4.40.0:
@@ -6914,7 +6936,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-loongarch64-gnu@4.40.0:
@@ -6929,7 +6950,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-powerpc64le-gnu@4.40.0:
@@ -6944,7 +6964,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-riscv64-gnu@4.40.0:
@@ -6959,7 +6978,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-riscv64-musl@4.40.0:
@@ -6974,7 +6992,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-s390x-gnu@4.40.0:
@@ -6989,7 +7006,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-x64-gnu@4.40.0:
@@ -7004,7 +7020,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-x64-musl@4.40.0:
@@ -7019,7 +7034,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-win32-arm64-msvc@4.40.0:
@@ -7034,7 +7048,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-win32-ia32-msvc@4.40.0:
@@ -7049,7 +7062,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-win32-x64-msvc@4.40.0:
@@ -7064,7 +7076,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rtsao/scc@1.1.0:
@@ -7838,6 +7849,12 @@ packages:
 
   /@types/unist@3.0.3:
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  /@types/xml2js@0.4.14:
+    resolution: {integrity: sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==}
+    dependencies:
+      '@types/node': 20.14.9
+    dev: true
 
   /@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.0)(typescript@5.5.4):
     resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
@@ -16887,7 +16904,6 @@ packages:
       '@rollup/rollup-win32-ia32-msvc': 4.40.1
       '@rollup/rollup-win32-x64-msvc': 4.40.1
       fsevents: 2.3.3
-    dev: true
 
   /rspack-resolver@1.2.2:
     resolution: {integrity: sha512-Fwc19jMBA3g+fxDJH2B4WxwZjE0VaaOL7OX/A4Wn5Zv7bOD/vyPZhzXfaO73Xc2GAlfi96g5fGUa378WbIGfFw==}
@@ -16959,6 +16975,10 @@ packages:
 
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  /sax@1.4.1:
+    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
+    dev: false
 
   /scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -19261,7 +19281,7 @@ packages:
       '@types/node': 20.14.9
       esbuild: 0.21.5
       postcss: 8.5.3
-      rollup: 4.40.0
+      rollup: 4.40.1
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -19299,7 +19319,7 @@ packages:
       '@types/node': 22.10.5
       esbuild: 0.21.5
       postcss: 8.5.3
-      rollup: 4.40.0
+      rollup: 4.40.1
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -19613,6 +19633,19 @@ packages:
       utf-8-validate:
         optional: true
     dev: true
+
+  /xml2js@0.6.2:
+    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      sax: 1.4.1
+      xmlbuilder: 11.0.1
+    dev: false
+
+  /xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
+    dev: false
 
   /xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}

--- a/samples/xml/README.md
+++ b/samples/xml/README.md
@@ -1,0 +1,12 @@
+---
+title: CLI
+description: Basic example of a custom parser
+tags:
+  - parser
+  - xml
+  - custom
+adapter: cli
+---
+
+This example demonstrates how to use a custom parser.
+In this case, a custom parser is defined to parse XML files.

--- a/samples/xml/app.ts
+++ b/samples/xml/app.ts
@@ -1,0 +1,13 @@
+import { allMovies } from "content-collections";
+
+for (const movie of allMovies) {
+  console.log("---");
+  console.log(movie.title);
+  console.log(movie.description);
+  console.log(movie.year);
+  console.log(movie.genres);
+  // @ts-expect-error content is not in the schema
+  if (movie.content) {
+    console.log("it has content, but it shouldn't");
+  }
+}

--- a/samples/xml/content-collections.ts
+++ b/samples/xml/content-collections.ts
@@ -1,0 +1,43 @@
+import {
+  defineCollection,
+  defineConfig,
+  defineParser,
+} from "@content-collections/core";
+import xml2js from "xml2js";
+
+const xmlParser = new xml2js.Parser({
+  explicitRoot: false,
+  explicitArray: false,
+});
+
+const parser = defineParser(xmlParser.parseStringPromise);
+
+const movies = defineCollection({
+  name: "movies",
+  directory: "movies",
+  include: "*.xml",
+  parser,
+  schema: (z) => ({
+    title: z.string(),
+    description: z.string(),
+    // xml2js returns a string instead of a number
+    year: z.coerce.number().min(1888).max(new Date().getFullYear()),
+    // genres is a wrapper around the genre elements
+    genres: z
+      .object({
+        // xml2js returns a string if only one genre is present
+        genre: z.union([z.string(), z.array(z.string())]),
+      })
+      // remove the wrapper and always return an array
+      .transform((val) => {
+        if (Array.isArray(val.genre)) {
+          return val.genre;
+        }
+        return [val.genre];
+      }),
+  }),
+});
+
+export default defineConfig({
+  collections: [movies],
+});

--- a/samples/xml/movies/2001-a-space-odyssey.xml
+++ b/samples/xml/movies/2001-a-space-odyssey.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<movie>
+  <title>2001: A Space Odyssey</title>
+  <description>A contemplative science fiction epic that traces human evolution from the dawn of man to a journey into the cosmos, featuring a mysterious black monolith and a sentient computer named HAL.</description>
+  <year>1968</year>
+  <genres>
+    <genre>Science Fiction</genre>
+    <genre>Adventure</genre>
+  </genres>
+</movie>

--- a/samples/xml/movies/casablanca.xml
+++ b/samples/xml/movies/casablanca.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<movie>
+  <title>Casablanca</title>
+  <description>Set during World War II, American expatriate Rick Blaine must choose between his love for a woman and helping her resistance leader husband escape from Casablanca to continue fighting the Nazis.</description>
+  <year>1942</year>
+  <genres>
+    <genre>Drama</genre>
+    <genre>Romance</genre>
+    <genre>War</genre>
+  </genres>
+</movie>

--- a/samples/xml/movies/citizen-kane.xml
+++ b/samples/xml/movies/citizen-kane.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<movie>
+  <title>Citizen Kane</title>
+  <description>Following the death of publishing tycoon Charles Foster Kane, reporters scramble to uncover the meaning of his final utterance, "Rosebud," revealing the rise and fall of a complex man.</description>
+  <year>1941</year>
+  <genres>
+    <genre>Drama</genre>
+    <genre>Mystery</genre>
+  </genres>
+</movie>

--- a/samples/xml/movies/parasite.xml
+++ b/samples/xml/movies/parasite.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<movie>
+  <title>Parasite</title>
+  <description>A poor family schemes to become employed by a wealthy household by infiltrating their home, leading to an unexpected incident that threatens their newfound comfort.</description>
+  <year>2019</year>
+  <genres>
+    <genre>Drama</genre>
+    <genre>Thriller</genre>
+    <genre>Comedy</genre>
+  </genres>
+</movie>

--- a/samples/xml/movies/pulp-fiction.xml
+++ b/samples/xml/movies/pulp-fiction.xml
@@ -1,0 +1,9 @@
+<movie>
+  <title>Pulp Fiction</title>
+  <description>A nonlinear narrative connecting the intersecting lives of Los Angeles mobsters, small-time criminals, and a mysterious briefcase, told through a series of interconnected stories.</description>
+  <year>1994</year>
+  <genres>
+    <genre>Crime</genre>
+    <genre>Drama</genre>
+  </genres>
+</movie>

--- a/samples/xml/movies/schindlers-list.xml
+++ b/samples/xml/movies/schindlers-list.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<movie>
+  <title>Schindler's List</title>
+  <description>The true story of Oskar Schindler, a German businessman who saved the lives of more than a thousand Jewish refugees during the Holocaust by employing them in his factories.</description>
+  <year>1993</year>
+  <genres>
+    <genre>Biography</genre>
+    <genre>Drama</genre>
+    <genre>History</genre>
+  </genres>
+</movie>

--- a/samples/xml/movies/seven-samurai.xml
+++ b/samples/xml/movies/seven-samurai.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<movie>
+  <title>Seven Samurai</title>
+  <description>In feudal Japan, a village of farmers hire seven masterless samurai to protect them from bandits who will return after the harvest to steal their crops.</description>
+  <year>1954</year>
+  <genres>
+    <genre>Action</genre>
+    <genre>Drama</genre>
+    <genre>Adventure</genre>
+  </genres>
+</movie>

--- a/samples/xml/movies/the-godfather.xml
+++ b/samples/xml/movies/the-godfather.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<movie>
+  <title>The Godfather</title>
+  <description>An epic crime drama following the Corleone family under patriarch Vito Corleone, depicting the transformation of his son Michael from reluctant outsider to ruthless mafia boss.</description>
+  <year>1972</year>
+  <genres>
+    <genre>Crime</genre>
+    <genre>Drama</genre>
+  </genres>
+</movie>

--- a/samples/xml/movies/the-shawshank-redemption.xml
+++ b/samples/xml/movies/the-shawshank-redemption.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<movie>
+  <title>The Shawshank Redemption</title>
+  <description>A banker named Andy Dufresne is sentenced to life in Shawshank State Prison for murders he didn't commit, where he forms a friendship with fellow inmate Ellis "Red" Redding and finds hope amid desperate circumstances.</description>
+  <year>1994</year>
+  <genres>
+    <genre>Drama</genre>
+  </genres>
+</movie>

--- a/samples/xml/movies/the-wizard-of-oz.xml
+++ b/samples/xml/movies/the-wizard-of-oz.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<movie>
+  <title>The Wizard of Oz</title>
+  <description>Young Dorothy Gale is swept away from her Kansas farm to the magical Land of Oz, where she embarks on a quest with her new friends to see the Wizard who can help her return home.</description>
+  <year>1939</year>
+  <genres>
+    <genre>Adventure</genre>
+    <genre>Fantasy</genre>
+    <genre>Musical</genre>
+  </genres>
+</movie>

--- a/samples/xml/package.json
+++ b/samples/xml/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "samples-xml",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "content-collections build",
+    "typecheck": "tsc",
+    "test": "vitest --run"
+  },
+  "dependencies": {
+    "@content-collections/cli": "0.1.6",
+    "@content-collections/core": "0.8.2",
+    "xml2js": "^0.6.2"
+  },
+  "devDependencies": {
+    "@types/node": "20",
+    "@types/xml2js": "^0.4.14",
+    "tsx": "^4.19.2",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.6",
+    "vitest": "^3.1.3"
+  }
+}

--- a/samples/xml/simple.test.ts
+++ b/samples/xml/simple.test.ts
@@ -1,0 +1,14 @@
+import { allMovies } from "content-collections";
+import { describe, expect, it } from "vitest";
+
+describe("simple", () => {
+  it("should collect 10 movies", () => {
+    expect(allMovies).toHaveLength(10);
+  });
+
+  it("should collect and parse", () => {
+    const titles = allMovies.map((movie) => movie.title);
+    expect(titles).toContain("The Shawshank Redemption");
+    expect(titles).toContain("The Godfather");
+  });
+});

--- a/samples/xml/tsconfig.json
+++ b/samples/xml/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    /* Base Options: */
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "es2022",
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    /* Strictness */
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    /* If NOT transpiling with TypeScript: */
+    "moduleResolution": "Bundler",
+    "module": "ESNext",
+    "noEmit": true,
+    /* If your code doesn't run in the DOM: */
+    "lib": ["es2022"],
+    /* import generated collection with content-collections */
+    "baseUrl": ".",
+    "paths": {
+      "content-collections": ["./.content-collections/generated"]
+    }
+  }
+}

--- a/samples/xml/vite.config.ts
+++ b/samples/xml/vite.config.ts
@@ -1,0 +1,14 @@
+// vite.config.js
+import path from "path";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "content-collections": path.resolve(
+        __dirname,
+        "./.content-collections/generated",
+      ),
+    },
+  },
+});


### PR DESCRIPTION
Add a new function to the core for creating custom parsers. The function is called defineParser.
The result of this function can be passed to the parser property of a collection.