### PR TITLE
chore: #578 add missing information to package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@content-collections/cli",
-  "description": "Command line interface for content-collections",
-  "version": "0.1.6",
   "type": "module",
+  "version": "0.1.6",
+  "description": "Command line interface for content-collections",
+  "author": "Sebastian Sdorra <s.sdorra@gmail.com>",
+  "license": "MIT",
+  "homepage": "https://content-collections.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sdorra/content-collections.git",
+    "directory": "packages/cli"
+  },
+  "bugs": "https://github.com/sdorra/content-collections/issues",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/packages/content-collections/package.json
+++ b/packages/content-collections/package.json
@@ -1,8 +1,17 @@
 {
   "name": "content-collections",
-  "description": "Installer for content-collections",
-  "version": "0.2.0",
   "type": "module",
+  "version": "0.2.0",
+  "description": "Installer for content-collections",
+  "author": "Sebastian Sdorra <s.sdorra@gmail.com>",
+  "license": "MIT",
+  "homepage": "https://content-collections.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sdorra/content-collections.git",
+    "directory": "packages/content-collections"
+  },
+  "bugs": "https://github.com/sdorra/content-collections/issues",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,17 @@
 {
   "name": "@content-collections/core",
-  "version": "0.9.0",
   "type": "module",
+  "version": "0.9.0",
+  "description": "Core of Content Collections",
+  "author": "Sebastian Sdorra <s.sdorra@gmail.com>",
+  "license": "MIT",
+  "homepage": "https://content-collections.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sdorra/content-collections.git",
+    "directory": "packages/core"
+  },
+  "bugs": "https://github.com/sdorra/content-collections/issues",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@content-collections/installer",
-  "description": "CLI for installing content-collections",
-  "version": "0.4.0",
   "type": "module",
+  "version": "0.4.0",
+  "description": "Automatic installer for content-collections",
+  "author": "Sebastian Sdorra <s.sdorra@gmail.com>",
+  "license": "MIT",
+  "homepage": "https://content-collections.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sdorra/content-collections.git",
+    "directory": "packages/installer"
+  },
+  "bugs": "https://github.com/sdorra/content-collections/issues",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@content-collections/integrations",
-  "description": "Utils for integrating Content Collections with other tools",
-  "version": "0.2.1",
   "type": "module",
+  "version": "0.2.1",
+  "description": "Utils for integrating Content Collections with other tools",
+  "author": "Sebastian Sdorra <s.sdorra@gmail.com>",
+  "license": "MIT",
+  "homepage": "https://content-collections.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sdorra/content-collections.git",
+    "directory": "packages/integrations"
+  },
+  "bugs": "https://github.com/sdorra/content-collections/issues",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@content-collections/markdown",
-  "description": "Compile markdown to html as part of your content-collection transform function",
-  "version": "0.1.4",
   "type": "module",
+  "version": "0.1.4",
+  "description": "Compile markdown to html as part of your content-collection transform function",
+  "author": "Sebastian Sdorra <s.sdorra@gmail.com>",
+  "license": "MIT",
+  "homepage": "https://content-collections.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sdorra/content-collections.git",
+    "directory": "packages/markdown"
+  },
+  "bugs": "https://github.com/sdorra/content-collections/issues",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@content-collections/mdx",
-  "description": "Compile MDX as part of your content-collection transform function",
-  "version": "0.2.2",
   "type": "module",
+  "version": "0.2.2",
+  "description": "Compile MDX as part of your content-collection transform function",
+  "author": "Sebastian Sdorra <s.sdorra@gmail.com>",
+  "license": "MIT",
+  "homepage": "https://content-collections.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sdorra/content-collections.git",
+    "directory": "packages/mdx"
+  },
+  "bugs": "https://github.com/sdorra/content-collections/issues",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@content-collections/next",
-  "description": "Use content-collection with Next.js",
-  "version": "0.2.6",
   "type": "module",
+  "version": "0.2.6",
+  "description": "Use content-collection with Next.js",
+  "author": "Sebastian Sdorra <s.sdorra@gmail.com>",
+  "license": "MIT",
+  "homepage": "https://content-collections.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sdorra/content-collections.git",
+    "directory": "packages/next"
+  },
+  "bugs": "https://github.com/sdorra/content-collections/issues",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/remix-vite/package.json
+++ b/packages/remix-vite/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@content-collections/remix-vite",
-  "description": "Use content-collections with Remix + Vite",
-  "version": "0.2.0",
   "type": "module",
+  "version": "0.2.0",
+  "description": "Use content-collections with Remix + Vite",
+  "author": "Sebastian Sdorra <s.sdorra@gmail.com>",
+  "license": "MIT",
+  "homepage": "https://content-collections.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sdorra/content-collections.git",
+    "directory": "packages/remix-vite"
+  },
+  "bugs": "https://github.com/sdorra/content-collections/issues",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/vinxi/package.json
+++ b/packages/vinxi/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@content-collections/vinxi",
-  "description": "Use content-collections with vinxi based frameworks",
-  "version": "0.1.0",
   "type": "module",
+  "version": "0.1.0",
+  "description": "Use content-collections with vinxi based frameworks",
+  "author": "Sebastian Sdorra <s.sdorra@gmail.com>",
+  "license": "MIT",
+  "homepage": "https://content-collections.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sdorra/content-collections.git",
+    "directory": "packages/vinxi"
+  },
+  "bugs": "https://github.com/sdorra/content-collections/issues",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@content-collections/vite",
-  "description": "Use content-collections with Vite",
-  "version": "0.2.4",
   "type": "module",
+  "version": "0.2.4",
+  "description": "Use content-collections with Vite",
+  "author": "Sebastian Sdorra <s.sdorra@gmail.com>",
+  "license": "MIT",
+  "homepage": "https://content-collections.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sdorra/content-collections.git",
+    "directory": "packages/vite"
+  },
+  "bugs": "https://github.com/sdorra/content-collections/issues",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
This should fix the missing changelog in tools like renovate.

Closes: #578