### PR TITLE
Use the `customViteReactPlugin` option in tanstack configuration

### DIFF
--- a/docs/quickstart/tanstack-start.mdx
+++ b/docs/quickstart/tanstack-start.mdx
@@ -57,6 +57,7 @@ import contentCollections from "@content-collections/vite";
 import { defineConfig } from "vite";
 import tsConfigPaths from "vite-tsconfig-paths";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+import viteReact from '@vitejs/plugin-react'
 
 export default defineConfig({
   vite: {
@@ -65,7 +66,8 @@ export default defineConfig({
       tsConfigPaths({
         projects: ["./tsconfig.json"],
       }),
-      tanstackStart()
+      tanstackStart({ customViteReactPlugin: true }),
+      viteReact()
     ],
   },
 });


### PR DESCRIPTION
Recently TanStack Start introduced using the `customViteReactPlugin` option in the configuration because soon this will become a norm so that we can choose which vite react plugin (or solidjs plugin) we want to use

<img width="901" height="464" alt="image" src="https://github.com/user-attachments/assets/476ff639-8ea6-47d8-beed-f7169e9485f9" />
