### PR TITLE
fix(core): #628 accept ReadonlyArray as valid return type

### DIFF
--- a/.changeset/loud-cobras-invent.md
+++ b/.changeset/loud-cobras-invent.md
@@ -1,0 +1,5 @@
+---
+"@content-collections/core": patch
+---
+
+Accept ReadonlyArray as valid return type of transform function

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts -d dist",
     "typecheck": "tsc",
-    "test": "vitest --run --coverage",
+    "test": "vitest --run --coverage --typecheck",
     "prepack": "cp ../../README.md ./README.md",
     "postpack": "rm -f ./README.md"
   },

--- a/packages/core/src/serializer.test-d.ts
+++ b/packages/core/src/serializer.test-d.ts
@@ -1,0 +1,21 @@
+import { assertType, test } from "vitest";
+import type { Serializable } from "./serializer";
+import { describe } from "node:test";
+
+describe("Serializable", () => {
+  test("should accept objects with arrays", () => {
+    const obj = {
+      items: [1, 2, 3],
+    };
+
+    assertType<Serializable>(obj);
+  });
+
+  test("should accept objects with readonly arrays", () => {
+    const obj = {
+      items: Object.freeze([1, 2, 3]),
+    };
+
+    assertType<Serializable>(obj);
+  });
+});

--- a/packages/core/src/serializer.test.ts
+++ b/packages/core/src/serializer.test.ts
@@ -148,7 +148,7 @@ describe("serializer", () => {
         const imported = await writeAndImport(tmpdir, object);
         expect(imported).toEqual([object]);
         expect(imported[0].bigint).toBeTypeOf("bigint");
-      },
+      }
     );
 
     tmpdirTest(
@@ -161,7 +161,7 @@ describe("serializer", () => {
 
         const imported = await writeAndImport(tmpdir, object);
         expect(imported).toEqual([{ name: "sample", fso: fs }]);
-      },
+      }
     );
 
     tmpdirTest(
@@ -176,7 +176,7 @@ describe("serializer", () => {
 
         const [imported] = await writeAndImport(tmpdir, object);
         expect(imported.imports.fso).toEqual(fs);
-      },
+      }
     );
 
     tmpdirTest(
@@ -193,7 +193,7 @@ describe("serializer", () => {
         const [imported] = await writeAndImport(tmpdir, object);
         expect(imported.imports.fs).toEqual(fs);
         expect(imported.imports.path).toEqual(path);
-      },
+      }
     );
 
     tmpdirTest(
@@ -210,7 +210,7 @@ describe("serializer", () => {
         const [imported] = await writeAndImport(tmpdir, object);
         expect(imported.imports[0]).toEqual(fs);
         expect(imported.imports[1]).toEqual(path);
-      },
+      }
     );
 
     tmpdirTest(
@@ -223,7 +223,7 @@ describe("serializer", () => {
 
         const [imported] = await writeAndImport(tmpdir, object);
         expect(imported.join).toEqual(path.join);
-      },
+      }
     );
   });
 });

--- a/packages/core/src/serializer.ts
+++ b/packages/core/src/serializer.ts
@@ -22,10 +22,13 @@ const literalSchema = z.union([
 
 type Literal = z.infer<typeof literalSchema>;
 
-type SchemaType = Literal | { [key: string]: SchemaType } | SchemaType[];
+type SchemaType =
+  | Literal
+  | { [key: string]: SchemaType }
+  | ReadonlyArray<SchemaType>;
 
 const schema: z.ZodType<SchemaType> = z.lazy(() =>
-  z.union([literalSchema, z.array(schema), z.record(schema)]),
+  z.union([literalSchema, z.array(schema), z.record(schema)])
 );
 
 export type NotSerializableError =

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "vitest/config";
 
-const excludes = ["**/__tests__/**", "**/types.ts", "**/*.test.ts"];
+const excludes = ["**/__tests__/**", "**/types.ts", "**/*.test.ts", "**/*.test-d.ts"];
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
Extend the allowed return types of the transform function to include ReadonlyArray.

Closes: #628