### PR TITLE
handle windows paths in import creators

### DIFF
--- a/.changeset/gold-boxes-dream.md
+++ b/.changeset/gold-boxes-dream.md
@@ -1,0 +1,5 @@
+---
+"@content-collections/core": patch
+---
+
+Handle Windows backslashes in import paths by automatically normalizing them to forward slashes in import creator functions.

--- a/packages/core/src/__spec__/transform.spec.ts
+++ b/packages/core/src/__spec__/transform.spec.ts
@@ -528,8 +528,7 @@ describe("workspace tests", () => {
             ...doc,
             greet: createNamedImport<(name: string) => string>(
               "greet",
-              // TODO: should createNamedImport handle the slash replacement on windows?
-              path.join(workspacePath, "src/greet.ts").replace(/\\/g, "/"),
+              path.join(workspacePath, "src/greet.ts"),
             ),
           };
         },
@@ -585,8 +584,7 @@ describe("workspace tests", () => {
           return {
             ...doc,
             greet: createDefaultImport<(name: string) => string>(
-              // TODO: should createDefaultImport handle the slash replacement on windows?
-              path.join(workspacePath, "src/greet.ts").replace(/\\/g, "/"),
+              path.join(workspacePath, "src/greet.ts"),
             ),
           };
         },

--- a/packages/core/src/import.ts
+++ b/packages/core/src/import.ts
@@ -17,14 +17,14 @@ export function isImport(value: any): value is Import<any> {
 export function createDefaultImport<T>(path: string): Import<T> {
   return {
     __cc_import: true,
-    path,
+    path: path.replace(/\\/g, "/"),
   };
 }
 
 export function createNamedImport<T>(name: string, path: string): Import<T> {
   return {
     __cc_import: true,
-    path,
+    path: path.replace(/\\/g, "/"),
     name,
   };
 }


### PR DESCRIPTION
addresses existing `TODO` items in the core package regarding windows-style path handling for generated imports.

improve dx by making the import creation robust. consumers of these functions no longer need to manually sanitize paths when creating imports for transformed documents.