### PR TITLE
Explicitly allow TypeScript 6 as peer dependency

### DIFF
--- a/.changeset/unlucky-pumas-rhyme.md
+++ b/.changeset/unlucky-pumas-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@content-collections/core": patch
+---
+
+Explicitly allow TypeScript 6 as peer dependency

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
     "postpack": "rm -f ./README.md"
   },
   "peerDependencies": {
-    "typescript": "^5.0.2"
+    "typescript": "^5.0.2 || ^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.9",


### PR DESCRIPTION
In https://github.com/sdorra/content-collections/commit/414aad15c5485f4e8b78d3f35f4b97eeffe5f875, it appears the intent was to allow 5.0.2 or any newer version. This expands the range to the recently released 6.0 (and versions below 7.0).

**Caveat:** I'm attempting to address an issue I noticed with `@content-collections/core` _as a transitive dependency_. I don't know much about the package/project (yet), so please forgive any ignorance on my part. I don't know how TypeScript is actually used by this package, so I'm not sure if it's actually safe to incorporate changes in 6.0, which are a bit more breaking than a typical release.

**Note:** I will take the opportunity to point out that, if there are issues with 6.0, the original value of `^5.0.2` may have already been problematic/risky. TypeScript releases don't follow semver[^1]: every point release has breaking changes, and they tend to cluster the highest-impact ones around x.0/x.5.

[^1]: It's possible that they'll reconsider this with 7.0 (the Go rewrite). I can't recall if they've addressed this.