### PR TITLE
fix issue #769 -- ResolveImports was expanding built-in object types (e.g. Date) into structural interface members instead of preserving them

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -239,13 +239,11 @@ type ResolveImports<TTransformResult> =
       ? Array<ResolveImports<U>>
       : TTransformResult extends (...args: any[]) => any
         ? TTransformResult
-        : TTransformResult extends object
-          ? {
-              [K in keyof TTransformResult]: ResolveImports<
-                TTransformResult[K]
-              >;
-            }
-          : TTransformResult;
+        : TTransformResult extends (Date | RegExp | Map<any, any> | Set<any> | WeakMap<any, any> | WeakSet<any> | Promise<any>)
+         ? TTransformResult
+         : TTransformResult extends object
+           ? { [K in keyof TTransformResult]: ResolveImports<TTransformResult[K]> }
+           : TTransformResult;
 
 export function defineCollection<
   TName extends string,


### PR DESCRIPTION
ResolveImports was expanding built-in object types (e.g. Date) into structural interface members instead of preserving them

See #769 for details