### PR TITLE
chore(core): bump chokidar from 4.0.3 to 5.0.0

### DIFF
--- a/.changeset/quick-books-play.md
+++ b/.changeset/quick-books-play.md
@@ -1,0 +1,5 @@
+---
+"@content-collections/core": patch
+---
+
+Fix installation with pnpm and trust policy no-downgrade

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@standard-schema/spec": "^1.0.0",
     "camelcase": "^8.0.0",
-    "chokidar": "^4.0.3",
+    "chokidar": "^5.0.0",
     "esbuild": "^0.25.11",
     "gray-matter": "^4.0.3",
     "p-limit": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,8 +116,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       chokidar:
-        specifier: ^4.0.3
-        version: 4.0.3
+        specifier: ^5.0.0
+        version: 5.0.0
       esbuild:
         specifier: ^0.25.11
         version: 0.25.12
@@ -6186,6 +6186,10 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
@@ -10170,6 +10174,10 @@ packages:
   readdirp@4.0.2:
     resolution: {integrity: sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==}
     engines: {node: '>= 14.16.0'}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
@@ -17446,6 +17454,10 @@ snapshots:
     dependencies:
       readdirp: 4.0.2
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   chownr@1.1.4: {}
 
   chownr@2.0.0: {}
@@ -22485,6 +22497,8 @@ snapshots:
       picomatch: 2.3.2
 
   readdirp@4.0.2: {}
+
+  readdirp@5.0.0: {}
 
   recast@0.23.11:
     dependencies:


### PR DESCRIPTION
- Updates chokidar from v4.0.3 to major version 5

Tests, build, typecheck passes. The update doesn't seem to have necessitated any changes (node.js version min. version is now 20.19, some type changes, ESM only)

5.0.0 introduces token-less trusted publishing. Also, chokidar 4.0.3 errors with pnpm trustpolicy due to 4.0.2/3 lacking provenance (https://github.com/paulmillr/chokidar/issues/1440#issuecomment-3610663676)